### PR TITLE
feat(tools): `readAssetBoxConfig` support js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ bin/
 .eslintcache
 
 dist
-assetbox.config.json
+assetbox.config.*
 packages/cli/src/assets/

--- a/packages/cli/src/initialize.ts
+++ b/packages/cli/src/initialize.ts
@@ -17,7 +17,7 @@ export const initialize = async () => {
   if (shouldDefault) {
     assetPath = "./src/assets/**/*";
   } else {
-    console.log("Please write assetbox.config.json yourself.");
+    console.log("Please write assetbox.config.js yourself.");
   }
 
   const packageRoot = findPackageRoot(process.cwd());
@@ -26,7 +26,10 @@ export const initialize = async () => {
   }
 
   await fs.writeFile(
-    resolve(packageRoot, "assetbox.config.json"),
-    JSON.stringify({ assetPaths: [assetPath] }, null, 2)
+    resolve(packageRoot, "assetbox.config.cjs"),
+    `module.exports = {
+  assetPaths: [${`"${assetPath}"`}],
+};
+`
   );
 };

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "glob": "^9.3.0",
+    "lilconfig": "^2.1.0",
     "workspace-tools": "^0.30.0"
   },
   "devDependencies": {

--- a/packages/tools/src/findAssetPaths.ts
+++ b/packages/tools/src/findAssetPaths.ts
@@ -1,23 +1,16 @@
-import fs from "fs/promises";
 import glob from "glob";
-import { resolve } from "path";
-import { findPackageRoot } from "workspace-tools";
 
 import { ASSET_EXTENSIONS } from "./common/const";
+import { readAssetBoxConfig } from "./readAssetBoxConfig";
 
 export const findAssetPaths = async () => {
-  const configPath = resolve(
-    findPackageRoot(process.cwd())!,
-    "assetbox.config.json"
-  );
-  const data = await fs.readFile(configPath);
-  const json = JSON.parse(data.toString());
+  const { assetPaths } = await readAssetBoxConfig();
 
   const fileList = await Promise.all(
-    json.assetPaths.map((assetPath: string) => glob(assetPath))
+    assetPaths.map((assetPath: string) => glob(assetPath))
   );
   return fileList.flat().filter((file) => {
-    const fileExtension = file.split(".").pop().toLowerCase();
-    return ASSET_EXTENSIONS.includes(fileExtension);
+    const fileExtension = file.split(".").pop()?.toLowerCase();
+    return fileExtension && ASSET_EXTENSIONS.includes(fileExtension);
   });
 };

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./findAssetPaths";
+export * from "./readAssetBoxConfig";

--- a/packages/tools/src/readAssetBoxConfig.ts
+++ b/packages/tools/src/readAssetBoxConfig.ts
@@ -1,0 +1,23 @@
+import { lilconfig } from "lilconfig";
+import { findPackageRoot } from "workspace-tools";
+
+import type { AssetBoxConfig } from "./types";
+
+export const readAssetBoxConfig = async (): Promise<AssetBoxConfig> => {
+  // all keys are optional
+  const options = {
+    stopDir: findPackageRoot(process.cwd()),
+    searchPlaces: ["assetbox.config.js", "assetbox.config.cjs"],
+    ignoreEmptySearchPlaces: false,
+  };
+
+  const value = await lilconfig("assetBox", options).search();
+  if (!value) {
+    throw new Error("Couldn't find assetbox.config.js.");
+  }
+
+  return {
+    filepath: value.config,
+    ...value.config,
+  };
+};

--- a/packages/tools/src/readAssetBoxConfig.ts
+++ b/packages/tools/src/readAssetBoxConfig.ts
@@ -4,7 +4,6 @@ import { findPackageRoot } from "workspace-tools";
 import type { AssetBoxConfig } from "./types";
 
 export const readAssetBoxConfig = async (): Promise<AssetBoxConfig> => {
-  // all keys are optional
   const options = {
     stopDir: findPackageRoot(process.cwd()),
     searchPlaces: ["assetbox.config.js", "assetbox.config.cjs"],

--- a/packages/tools/src/types.ts
+++ b/packages/tools/src/types.ts
@@ -1,0 +1,3 @@
+export type AssetBoxConfig = {
+  assetPaths: string[];
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,6 @@ importers:
       '@types/react-dom': ^18.0.11
       express: ^4.18.2
       glob: ^9.3.0
-      lilconfig: ^2.1.0
       picocolors: ^1.0.0
       prompts: ^2.4.2
       react: ^18.2.0
@@ -63,7 +62,6 @@ importers:
       '@types/react-dom': 18.0.11
       express: 4.18.2
       glob: 9.3.0
-      lilconfig: 2.1.0
       picocolors: 1.0.0
       prompts: 2.4.2
       react: 18.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,7 @@ importers:
       '@types/react-dom': ^18.0.11
       express: ^4.18.2
       glob: ^9.3.0
+      lilconfig: ^2.1.0
       picocolors: ^1.0.0
       prompts: ^2.4.2
       react: ^18.2.0
@@ -62,6 +63,7 @@ importers:
       '@types/react-dom': 18.0.11
       express: 4.18.2
       glob: 9.3.0
+      lilconfig: 2.1.0
       picocolors: 1.0.0
       prompts: 2.4.2
       react: 18.2.0
@@ -102,9 +104,11 @@ importers:
     specifiers:
       '@types/node': ^18.15.3
       glob: ^9.3.0
+      lilconfig: ^2.1.0
       workspace-tools: ^0.30.0
     dependencies:
       glob: 9.3.0
+      lilconfig: 2.1.0
       workspace-tools: 0.30.0
     devDependencies:
       '@types/node': 18.15.3
@@ -2197,6 +2201,11 @@ packages:
     resolution: {integrity: sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==}
     engines: {node: '>=10'}
     dev: true
+
+  /lilconfig/2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+    engines: {node: '>=10'}
+    dev: false
 
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}


### PR DESCRIPTION
`assetbox.config.json` to `assetbox.config.js` 로 변경

이유는 정적값이 아닌 런타임을 거친 확정 값을 알아야함.

밑에 같은 조건부 코드, js 코드들 또한 다 작동함.

```js
// assset.config.js 파일

const assetPaths = prcoess.env.NODE_ENV === "development" ? ["src/assets/**/*] : ["src/prod-assets/**/*];

module.exports = {
  assetPaths,
};
```