### PR TITLE
UI Component: Select

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.14",
-    "@heroicons/react": "^2.0.18",
     "@radix-ui/react-checkbox": "^1.0.3",
     "@trpc/client": "^10.23.0",
     "@trpc/server": "^10.23.0",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -18,6 +18,8 @@
     "test:type": "tsc --noEmit"
   },
   "dependencies": {
+    "@headlessui/react": "^1.7.14",
+    "@heroicons/react": "^2.0.18",
     "@radix-ui/react-checkbox": "^1.0.3",
     "@trpc/client": "^10.23.0",
     "@trpc/server": "^10.23.0",

--- a/packages/manager/src/assets/down-vector.svg
+++ b/packages/manager/src/assets/down-vector.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="8" viewBox="0 0 13 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.4677 1.52942L6.49997 6.4706L1.53223 1.52942" stroke="black" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/manager/src/components/ui/Select.tsx
+++ b/packages/manager/src/components/ui/Select.tsx
@@ -1,5 +1,5 @@
 import { Listbox, Transition } from "@headlessui/react";
-import { ComponentProps, ReactNode } from "react";
+import { ComponentProps } from "react";
 
 import DownVector from "../../assets/down-vector.svg";
 import { cn } from "../../utils/cn";

--- a/packages/manager/src/components/ui/Select.tsx
+++ b/packages/manager/src/components/ui/Select.tsx
@@ -1,5 +1,5 @@
-import { Listbox } from "@headlessui/react";
-import { ComponentProps } from "react";
+import { Listbox, Transition } from "@headlessui/react";
+import { ComponentProps, ReactNode } from "react";
 
 import DownVector from "../../assets/down-vector.svg";
 import { cn } from "../../utils/cn";
@@ -27,19 +27,34 @@ Select.Button = ({
   return (
     <Listbox.Button
       className={cn(
-        "w-[165px] h-12 flex items-center  rounded bg-white px-[10px] mb-1"
+        "w-[165px] h-12 flex items-center rounded bg-white px-[10px] mb-1"
       )}
       {...props}
     >
-      <>
-        {children}
-        <DownVector className="ml-auto" />
-      </>
+      {({ open }) => (
+        <>
+          {children}
+          <DownVector
+            className={cn("ml-auto", open && "rotate-180 transform")}
+          />
+        </>
+      )}
     </Listbox.Button>
   );
 };
 Select.Options = ({ ...props }: ComponentProps<typeof Listbox.Options>) => {
-  return <Listbox.Options {...props} />;
+  return (
+    <Transition
+      enter="transition duration-100 ease-out"
+      enterFrom="transform scale-95 opacity-0"
+      enterTo="transform scale-100 opacity-100"
+      leave="transition duration-75 ease-out"
+      leaveFrom="transform scale-100 opacity-100"
+      leaveTo="transform scale-95 opacity-0"
+    >
+      <Listbox.Options {...props} />
+    </Transition>
+  );
 };
 
 type ClassNameArgs = {
@@ -51,7 +66,7 @@ Select.Option = ({
   className,
   ...props
 }: ComponentProps<typeof Listbox.Option> & {
-  className?: (args: ClassNameArgs) => string | string;
+  className?: ((args: ClassNameArgs) => string) | string;
 }) => {
   return (
     <Listbox.Option
@@ -59,7 +74,7 @@ Select.Option = ({
       className={({ active, selected }: ClassNameArgs) =>
         cn(
           "bg-white cursor-pointer text-base w-[165px] h-12 flex items-center border-b border-gray-light last:border-b-0 px-[10px]",
-          "first:rounded last:rounded",
+          "first:rounded-t last:rounded-b",
           active && "text-blue",
           typeof className === "function"
             ? className({ active, selected })

--- a/packages/manager/src/components/ui/Select.tsx
+++ b/packages/manager/src/components/ui/Select.tsx
@@ -1,17 +1,71 @@
 import { Listbox } from "@headlessui/react";
-import { CheckIcon } from "@heroicons/react/20/solid";
-export const Select = () => {
+import { ComponentProps } from "react";
+
+import DownVector from "../../assets/down-vector.svg";
+import { cn } from "../../utils/cn";
+export interface SelectProps {
+  selectedValue?: any;
+  onChange: (value: any) => void;
+}
+
+export const Select = ({
+  selectedValue,
+  onChange,
+  children,
+}: React.PropsWithChildren<SelectProps>) => {
   return (
-    <Listbox>
-      <Select.Button />
+    <Listbox value={selectedValue} onChange={onChange}>
+      {children}
     </Listbox>
   );
 };
 
-Select.Button = () => {
-  return <Listbox.Button></Listbox.Button>;
+Select.Button = ({
+  children,
+  ...props
+}: ComponentProps<typeof Listbox.Button>) => {
+  return (
+    <Listbox.Button
+      className={cn(
+        "w-[165px] h-12 flex items-center  rounded bg-white px-[10px] mb-1"
+      )}
+      {...props}
+    >
+      <>
+        {children}
+        <DownVector className="ml-auto" />
+      </>
+    </Listbox.Button>
+  );
+};
+Select.Options = ({ ...props }: ComponentProps<typeof Listbox.Options>) => {
+  return <Listbox.Options {...props} />;
 };
 
-Select.Option = () => {
-  return <Listbox.Options></Listbox.Options>;
+type ClassNameArgs = {
+  active: boolean;
+  selected: boolean;
+};
+
+Select.Option = ({
+  className,
+  ...props
+}: ComponentProps<typeof Listbox.Option> & {
+  className?: (args: ClassNameArgs) => string | string;
+}) => {
+  return (
+    <Listbox.Option
+      {...props}
+      className={({ active, selected }: ClassNameArgs) =>
+        cn(
+          "bg-white cursor-pointer text-base w-[165px] h-12 flex items-center border-b border-gray-light last:border-b-0 px-[10px]",
+          "first:rounded last:rounded",
+          active && "text-blue",
+          typeof className === "function"
+            ? className({ active, selected })
+            : className
+        )
+      }
+    />
+  );
 };

--- a/packages/manager/src/components/ui/Select.tsx
+++ b/packages/manager/src/components/ui/Select.tsx
@@ -1,0 +1,17 @@
+import { Listbox } from "@headlessui/react";
+import { CheckIcon } from "@heroicons/react/20/solid";
+export const Select = () => {
+  return (
+    <Listbox>
+      <Select.Button />
+    </Listbox>
+  );
+};
+
+Select.Button = () => {
+  return <Listbox.Button></Listbox.Button>;
+};
+
+Select.Option = () => {
+  return <Listbox.Options></Listbox.Options>;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.2.0
-        version: 4.2.0
+        version: 4.2.0(@types/node@18.15.3)
       vite-plugin-svgr:
         specifier: ^2.4.0
         version: 2.4.0(vite@4.2.0)
@@ -156,7 +156,7 @@ importers:
         version: 18.0.28
       esbuild-plugin-copy:
         specifier: ^2.1.1
-        version: 2.1.1
+        version: 2.1.1(esbuild@0.17.11)
       rollup-plugin-copy:
         specifier: ^3.4.0
         version: 3.4.0
@@ -166,6 +166,9 @@ importers:
 
   packages/manager:
     dependencies:
+      '@headlessui/react':
+        specifier: ^1.7.14
+        version: 1.7.14(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-checkbox':
         specifier: ^1.0.3
         version: 1.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -217,7 +220,7 @@ importers:
         version: 8.4.23
       tailwindcss:
         specifier: ^3.3.2
-        version: 3.3.2
+        version: 3.3.2(ts-node@10.9.1)
       typescript:
         specifier: ^4.9.3
         version: 4.9.5
@@ -266,13 +269,13 @@ importers:
         version: 29.5.0(@babel/core@7.21.5)
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@18.15.3)
+        version: 29.5.0(@types/node@18.15.3)(ts-node@10.9.1)
       memfs:
         specifier: ^3.5.1
         version: 3.5.1
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.21.5)(babel-jest@29.5.0)(jest@29.5.0)
+        version: 29.1.0(@babel/core@7.21.5)(babel-jest@29.5.0)(esbuild@0.17.11)(jest@29.5.0)(typescript@4.9.5)
 
   packages/trpc:
     dependencies:
@@ -1931,6 +1934,18 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@headlessui/react@1.7.14(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-znzdq9PG8rkwcu9oQ2FwIy0ZFtP9Z7ycS+BAqJ3R5EIqC/0bJGvhT7193rFf+45i9nnPsYvCQVW4V/bB9Xc+gA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16 || ^17 || ^18
+      react-dom: ^16 || ^17 || ^18
+    dependencies:
+      client-only: 0.0.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@humanwhocodes/config-array@0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
     engines: {node: '>=10.10.0'}
@@ -1979,7 +1994,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core@29.5.0:
+  /@jest/core@29.5.0(ts-node@10.9.1):
     resolution: {integrity: sha512-28UzQc7ulUrOQw1IsN/kv1QES3q2kkbl/wGslyhAclqZ/8cMdB5M68BffkIdSJgKBUt50d3hbwJ92XESlE7LiQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -2000,7 +2015,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@18.15.3)
+      jest-config: 29.5.0(@types/node@18.15.3)(ts-node@10.9.1)
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -3014,7 +3029,7 @@ packages:
       vite: ^4
     dependencies:
       '@swc/core': 1.3.40
-      vite: 4.2.0
+      vite: 4.2.0(@types/node@18.15.3)
 
   /@yarnpkg/lockfile@1.1.0:
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -3513,6 +3528,10 @@ packages:
       string-width: 5.1.2
     dev: true
 
+  /client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+    dev: false
+
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -3897,13 +3916,14 @@ packages:
       is-arrayish: 0.2.1
     dev: true
 
-  /esbuild-plugin-copy@2.1.1:
+  /esbuild-plugin-copy@2.1.1(esbuild@0.17.11):
     resolution: {integrity: sha512-Bk66jpevTcV8KMFzZI1P7MZKZ+uDcrZm2G2egZ2jNIvVnivDpodZI+/KnpL3Jnap0PBdIHU7HwFGB8r+vV5CVw==}
     peerDependencies:
       esbuild: '>= 0.14.0'
     dependencies:
       chalk: 4.1.2
       chokidar: 3.5.3
+      esbuild: 0.17.11
       fs-extra: 10.1.0
       globby: 11.1.0
     dev: true
@@ -4896,7 +4916,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.5.0(@types/node@18.15.3):
+  /jest-cli@29.5.0(@types/node@18.15.3)(ts-node@10.9.1):
     resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -4906,14 +4926,14 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0
+      '@jest/core': 29.5.0(ts-node@10.9.1)
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 29.5.0(@types/node@18.15.3)
+      jest-config: 29.5.0(@types/node@18.15.3)(ts-node@10.9.1)
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
@@ -4924,7 +4944,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.5.0(@types/node@18.15.3):
+  /jest-config@29.5.0(@types/node@18.15.3)(ts-node@10.9.1):
     resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -4959,6 +4979,7 @@ packages:
       pretty-format: 29.5.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
+      ts-node: 10.9.1(@types/node@18.15.3)(typescript@4.9.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5249,7 +5270,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.5.0(@types/node@18.15.3):
+  /jest@29.5.0(@types/node@18.15.3)(ts-node@10.9.1):
     resolution: {integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -5259,10 +5280,10 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0
+      '@jest/core': 29.5.0(ts-node@10.9.1)
       '@jest/types': 29.5.0
       import-local: 3.1.0
-      jest-cli: 29.5.0(@types/node@18.15.3)
+      jest-cli: 29.5.0(@types/node@18.15.3)(ts-node@10.9.1)
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -6049,7 +6070,7 @@ packages:
       postcss: 8.4.23
     dev: true
 
-  /postcss-load-config@4.0.1(postcss@8.4.23):
+  /postcss-load-config@4.0.1(postcss@8.4.23)(ts-node@10.9.1):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -6063,6 +6084,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.23
+      ts-node: 10.9.1(@types/node@18.15.3)(typescript@4.9.5)
       yaml: 2.2.1
     dev: true
 
@@ -6783,7 +6805,7 @@ packages:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: false
 
-  /tailwindcss@3.3.2:
+  /tailwindcss@3.3.2(ts-node@10.9.1):
     resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -6805,7 +6827,7 @@ packages:
       postcss: 8.4.23
       postcss-import: 15.1.0(postcss@8.4.23)
       postcss-js: 4.0.1(postcss@8.4.23)
-      postcss-load-config: 4.0.1(postcss@8.4.23)
+      postcss-load-config: 4.0.1(postcss@8.4.23)(ts-node@10.9.1)
       postcss-nested: 6.0.1(postcss@8.4.23)
       postcss-selector-parser: 6.0.12
       postcss-value-parser: 4.2.0
@@ -6907,7 +6929,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest@29.1.0(@babel/core@7.21.5)(babel-jest@29.5.0)(jest@29.5.0):
+  /ts-jest@29.1.0(@babel/core@7.21.5)(babel-jest@29.5.0)(esbuild@0.17.11)(jest@29.5.0)(typescript@4.9.5):
     resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -6931,13 +6953,15 @@ packages:
       '@babel/core': 7.21.5
       babel-jest: 29.5.0(@babel/core@7.21.5)
       bs-logger: 0.2.6
+      esbuild: 0.17.11
       fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@18.15.3)
+      jest: 29.5.0(@types/node@18.15.3)(ts-node@10.9.1)
       jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.8
+      typescript: 4.9.5
       yargs-parser: 21.1.1
     dev: true
 
@@ -7217,43 +7241,11 @@ packages:
     dependencies:
       '@rollup/pluginutils': 5.0.2
       '@svgr/core': 6.5.1
-      vite: 4.2.0
+      vite: 4.2.0(@types/node@18.15.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: true
-
-  /vite@4.2.0:
-    resolution: {integrity: sha512-AbDTyzzwuKoRtMIRLGNxhLRuv1FpRgdIw+1y6AQG73Q5+vtecmvzKo/yk8X/vrHDpETRTx01ABijqUHIzBXi0g==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.17.11
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 3.19.1
-    optionalDependencies:
-      fsevents: 2.3.2
 
   /vite@4.2.0(@types/node@18.15.3):
     resolution: {integrity: sha512-AbDTyzzwuKoRtMIRLGNxhLRuv1FpRgdIw+1y6AQG73Q5+vtecmvzKo/yk8X/vrHDpETRTx01ABijqUHIzBXi0g==}


### PR DESCRIPTION
## What To Do
이전에 PR 날린 Dropdown은 디자인 커스텀에 대한 한계가 있었습니다.
그래서 디자인은 같지만,  확장성을 높인 Select component를 구현했습니다.

`Select.Button` : 값을 선택했을 때, input box에 나타나는 값
`Select Options` `Select Option` :  input box의 리스트들을 나타내는 값

## Usage
`dupePage` (example)
```js
import { useState } from "react";

import { Select } from "../components/ui/Select";

const people = [
  { id: 1, name: "All", unavailable: false },
  { id: 2, name: "Desc", unavailable: false },
  { id: 3, name: "Asc", unavailable: false },
  { id: 4, name: "Desc", unavailable: false },
  { id: 5, name: "Asc", unavailable: false },
];
type People = (typeof people)[0];

export const DupePage = () => {
  const [selected, SetSelected] = useState<People>(people[0]);
  const handleChange = (value: People) => {
    SetSelected(value);
  };

  return (
    <div className="m-10">
      <Select selectedValue={selected} onChange={handleChange}>
        <Select.Button>{selected.name}</Select.Button>
        <Select.Options>
          {people.map((person) => (
            <Select.Option key={person.id} value={person}>
              {person.name}
            </Select.Option>
          ))}
        </Select.Options>
      </Select>
    </div>
  );
};

```