### PR TITLE
feat(plugin-react): iconBuild outDir deprecated to plugin outDir

### DIFF
--- a/example/react/assetbox.config.cjs
+++ b/example/react/assetbox.config.cjs
@@ -11,8 +11,11 @@ const config = {
   },
   trackingPaths: ["./src/**/*"],
   iconBuild: {
-    plugins: [react()],
-    outDir: "./icon-dist",
+    plugins: [
+      react({
+        outDir: "icon-dist",
+      }),
+    ],
   },
 };
 

--- a/frameworks/react/src/plugin.ts
+++ b/frameworks/react/src/plugin.ts
@@ -14,11 +14,17 @@ import {
 } from "./core";
 import { pipe } from "./utils";
 
-export const react = (): IconBuildPlugin => ({
-  name: "react-icon",
-  build: async ({ categories, iconBuild }) => {
-    const outDir = iconBuild!.outDir!;
+export type ReactPluginOptions = {
+  outDir: string;
+};
 
+export const react = (
+  { outDir }: ReactPluginOptions = {
+    outDir: "dist",
+  }
+): IconBuildPlugin => ({
+  name: "react-icon",
+  build: async ({ categories }) => {
     const progress = new cliProgress.SingleBar(
       {
         format: " {bar} | {task} | {value}/{total}",

--- a/packages/cli/src/commands/iconBuild.ts
+++ b/packages/cli/src/commands/iconBuild.ts
@@ -1,10 +1,8 @@
 import { readAssetBoxConfig } from "@assetbox/tools";
-import pc from "picocolors";
 
 export const iconBuild = async () => {
   const { iconBuild = {}, ...context } = await readAssetBoxConfig();
 
-  iconBuild.outDir = iconBuild.outDir ?? "dist";
   iconBuild.plugins = iconBuild.plugins ?? [];
 
   for (const plugin of iconBuild.plugins) {

--- a/packages/tools/src/types.ts
+++ b/packages/tools/src/types.ts
@@ -13,7 +13,6 @@ export type AssetBoxScheme = {
     base?: string;
   };
   iconBuild?: {
-    outDir?: string;
     plugins?: IconBuildPlugin[];
   };
   port?: number;


### PR DESCRIPTION
여러 플러그인  확장성을 고려해 outDir 이동

as-is
```js
const config = {
  ...
   iconBuild: {
      outDir: "icon-dist",
      plugins: [
        react(),
      ],
    }
   ...
}
```

to-be
```js
const config = {
  ...
   iconBuild: {
      plugins: [
        react({
          outDir: "icon-dist",
        }),
      ],
    }
   ...
}
```